### PR TITLE
feat: refine mobile layout

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -10,7 +10,7 @@ import TimelineStatusBar from '../components/TimelineStatusBar';
 
 export default function Home() {
   return (
-    <div className="h-screen overflow-hidden bg-black text-white flex flex-col">
+    <div className="min-h-screen overflow-x-hidden bg-black text-white flex flex-col">
       {/* Header */}
       <header className="p-4">
         <h1 className="text-2xl tracking-tighter font-bold text-gray-500 text-spacing-px">AGENT TRAFFIC CONTROL</h1>
@@ -20,8 +20,8 @@ export default function Home() {
       <div className="border-t border-gray-800" />
 
       {/* Main two-column layout */}
-      <main className="flex-1 overflow-hidden p-4">
-        <div className="grid grid-cols-1 lg:grid-cols-[30%_70%] gap-4 h-full min-h-0">
+      <main className="flex-1 p-4 overflow-x-hidden">
+        <div className="grid grid-cols-1 lg:grid-cols-[30%_70%] gap-4">
           {/* LEFT COLUMN: 3 rows -> [Monitoring (auto), Operator Actions (auto), Work/Agent table (1fr = remaining space)] */}
           <section className="min-h-0 overflow-hidden grid grid-rows-[auto_auto_1fr]">
             {/* Monitoring table (top) with three internal rows */}
@@ -56,13 +56,13 @@ export default function Home() {
             </div>
 
             {/* Work/Agent table (bottom, 75% height) */}
-            <div className="min-h-0 overflow-hidden">
+            <div className="min-h-0 overflow-hidden max-h-60 md:max-h-none">
               <WorkTable />
             </div>
           </section>
 
           {/* RIGHT COLUMN: rows -> [Top (1fr), Radar area (7fr), Master Control Panel (auto)] */}
-          <aside className="h-full min-h-0 overflow-hidden grid grid-rows-[1fr_7fr_auto] gap-3">
+          <aside className="min-h-0 overflow-hidden flex flex-col gap-3 lg:grid lg:grid-rows-[1fr_7fr_auto]">
             {/* Top row (same height as Monitoring row). Keep MetricsBar here. */}
             <div className="min-h-0 overflow-hidden bg-black">
               <TopOverview />
@@ -72,18 +72,19 @@ export default function Home() {
             <div className="min-h-0 overflow-hidden flex flex-col">
               {/* Full-width header bar with yellow tab, like Monitoring */}
               <div className="flex items-center" style={{ backgroundColor: '#130f04ff' }}>
-                <div style={{ width: '8%', backgroundColor: '#c79325' }}>
-                  <h2 className="pl-2 pr-2 font-bold text-black">GLOBAL QUEUE</h2>
+                <div className="w-full lg:w-[8%]" style={{ backgroundColor: '#c79325' }}>
+                  <h2 className="pl-2 pr-2 font-bold text-black hidden lg:block">GLOBAL QUEUE</h2>
+                  <h2 className="pl-2 pr-2 font-bold text-black lg:hidden">RADAR</h2>
                 </div>
               </div>
               {/* Two-column area: 10% ActionItems | 90% Radar */}
-              <div className="min-h-0 overflow-hidden grid" style={{ gridTemplateColumns: '8% 92%' }}>
+              <div className="min-h-0 overflow-hidden grid grid-cols-1 lg:grid-cols-[8%_92%]">
                 {/* Global Queue (left, full radar height) */}
-                <div className="border-r border-[#352b19ff] bg-black min-h-0 overflow-hidden">
+                <div className="bg-black min-h-0 overflow-hidden border-b border-[#352b19ff] lg:border-b-0 lg:border-r hidden lg:block">
                   <GlobalQueue />
                 </div>
                 {/* Radar (right) */}
-                <div className="min-h-0 overflow-hidden bg-black">
+                <div className="min-h-0 overflow-hidden bg-black h-64 md:h-80 lg:h-full">
                   <RadarCanvas message="" />
                 </div>
               </div>

--- a/components/TopOverview.tsx
+++ b/components/TopOverview.tsx
@@ -105,41 +105,41 @@ export default function TopOverview() {
     >
       {/* Main Metrics card */}
       <div style={{ background: '#000' }}>
-        <div className="text-lg text-[#d79326ff] pl-2 pr-2 bg-[#130f04ff]">MAIN METRICS</div>
+        <div className="text-base lg:text-lg text-[#d79326ff] pl-2 pr-2 bg-[#130f04ff]">MAIN METRICS</div>
         <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: 8, color: '#cfcfcf', padding: '8px' }}>
           <div style={{ display: 'flex', flexDirection: 'column' }}>
-            <div className="text-md" style={{ color: '#a0a0a0'}}>ACTIVE AGENTS</div>
-            <div className="text-xl" style={{ marginTop: 4 }}>{fmtInt(m.active_agents)}</div>
+            <div className="text-xs lg:text-sm" style={{ color: '#a0a0a0'}}>ACTIVE AGENTS</div>
+            <div className="text-lg lg:text-xl" style={{ marginTop: 4 }}>{fmtInt(m.active_agents)}</div>
           </div>
           <div style={{ display: 'flex', flexDirection: 'column' }}>
-            <div className="text-md" style={{ color: '#a0a0a0'}}>TOTAL TOKENS</div>
-            <div className="text-xl" style={{ marginTop: 4 }}>{fmtInt(m.total_tokens)}</div>
+            <div className="text-xs lg:text-sm" style={{ color: '#a0a0a0'}}>TOTAL TOKENS</div>
+            <div className="text-lg lg:text-xl" style={{ marginTop: 4 }}>{fmtInt(m.total_tokens)}</div>
           </div>
           <div style={{ display: 'flex', flexDirection: 'column' }}>
-            <div className="text-md" style={{ color: '#a0a0a0'}}>TOTAL SPEND</div>
-            <div className="text-xl" style={{ marginTop: 4 }}>{fmtUSD(m.total_spend_usd)}</div>
+            <div className="text-xs lg:text-sm" style={{ color: '#a0a0a0'}}>TOTAL SPEND</div>
+            <div className="text-lg lg:text-xl" style={{ marginTop: 4 }}>{fmtUSD(m.total_spend_usd)}</div>
           </div>
         </div>
       </div>
 
       {/* Live Throughput card */}
       <div style={{ background: '#000' }}>
-        <div className="text-lg text-[#d79326ff] pl-2 pr-2 bg-[#130f04ff]">LIVE THROUGHPUT</div>
+        <div className="text-base lg:text-lg text-[#d79326ff] pl-2 pr-2 bg-[#130f04ff]">LIVE THROUGHPUT</div>
         <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8, color: '#cfcfcf', padding: '8px' }}>
           <div style={{ display: 'flex', flexDirection: 'column' }}>
-            <div className="text-md" style={{ color: '#a0a0a0'}}>TOKENS / SEC</div>
-            <div className="text-xl" style={{ marginTop: 4 }}>{fmtFloat(m.live_tps, 2)}</div>
+            <div className="text-xs lg:text-sm" style={{ color: '#a0a0a0'}}>TOKENS / SEC</div>
+            <div className="text-lg lg:text-xl" style={{ marginTop: 4 }}>{fmtFloat(m.live_tps, 2)}</div>
           </div>
           <div style={{ display: 'flex', flexDirection: 'column' }}>
-            <div className="text-md" style={{ color: '#a0a0a0'}}>SPEND / SEC</div>
-            <div className="text-xl" style={{ marginTop: 4 }}>{fmtUSD(m.live_spend_per_s)}</div>
+            <div className="text-xs lg:text-sm" style={{ color: '#a0a0a0'}}>SPEND / SEC</div>
+            <div className="text-lg lg:text-xl" style={{ marginTop: 4 }}>{fmtUSD(m.live_spend_per_s)}</div>
           </div>
         </div>
       </div>
 
       {/* Project Completion Rate card */}
       <div style={{ background: '#000', display: 'flex', flexDirection: 'column', minHeight: 0 }}>
-        <div className="text-lg text-[#d79326ff] pl-2 pr-2 bg-[#130f04ff]">PROJECT COMPLETION RATE</div>
+        <div className="text-base lg:text-lg text-[#d79326ff] pl-2 pr-2 bg-[#130f04ff]">PROJECT COMPLETION RATE</div>
         <div style={{ padding: '8px', flex: 1, minHeight: 0 }}>
           <Chart points={points} containerRef={containerRef} />
         </div>


### PR DESCRIPTION
## Summary
- limit work table height on small screens with internal scrolling
- hide global queue on mobile and promote radar to full width
- shrink top overview metrics text for better mobile readability

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba6ba0c338832d9e9e4a9ba1058b69